### PR TITLE
Refactored aws/main.go to make a generic handler that can be used by …

### DIFF
--- a/scoring/common/handler.go
+++ b/scoring/common/handler.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Path-Check/Scoring-Service/model"
+)
+
+var (
+	ErrRequestBodyEmpty = errors.New("HTTP request body is empty")
+	ErrUnmarshalJSON = errors.New("Failed to unmarshal into JSON.")
+	ErrMarshalJSON = errors.New("Failed to marshal into JSON.")
+)
+
+// This is a handler that can be called by any cloud product specific handler
+// once cloud specific modifications have been done.
+// Returns: HTTP status code, response body, and error.
+func GenericHandler(requestBody string) (int, string, error) {
+	// If the HTTP request body is empty, throw an error.
+	if len(requestBody) == 0 {
+		return 400, "", ErrRequestBodyEmpty
+	}
+
+	enReq := model.ExposureNotificationRequest{}
+	err := json.Unmarshal([]byte(requestBody), &enReq)
+	if err != nil {
+		return 400, "", ErrUnmarshalJSON
+	}
+
+	enRes, err := model.ScoreV1(&enReq)
+	if err != nil {
+		return 400, "", err
+	}
+
+	response, err := json.Marshal(&enRes)
+	if err != nil {
+		return 400, "", ErrMarshalJSON
+	}
+
+	// Success! Return the response.
+	return 200, string(response), nil
+}

--- a/scoring/common/handler_test.go
+++ b/scoring/common/handler_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlerSuccess(t *testing.T) {
+	requestData := []byte(`
+	{
+		"new_exposure_summary":
+		{
+			"date_received": 1597482000,
+			"timezone_offset": 32400,
+			"seq_no_in_day": 1,
+			"attenuation_durations": {"low": 900, "medium": 0, "high": 0},
+			"matched_key_count": 1,
+			"days_since_last_exposure": 1,
+			"maximum_risk_score": 1,
+			"risk_score_sum": 1
+		}
+	}`)
+
+	// use RawMessage instead of Marshal to avoid escaping characters
+	rm := json.RawMessage(requestData)
+
+	rawJSON, _ := rm.MarshalJSON()
+	body := string(rawJSON)
+
+	expectedResponse := "{\"notifications\":[{\"exposure_summaries\":[{\"date_received\":1597482000,\"timezone_offset\":32400,\"seq_no_in_day\":1,\"attenuation_durations\":{\"low\":900,\"medium\":0,\"high\":0},\"matched_key_count\":1,\"days_since_last_exposure\":1,\"maximum_risk_score\":1,\"risk_score_sum\":1}],\"duration_seconds\":900,\"date_of_exposure\":1597395600}]}"
+
+	// Test a successful request.
+	status, response, err := GenericHandler(body)
+	assert.Equal(t, 200, status)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedResponse, response)
+}
+
+func TestEmptyBodyError(t *testing.T) {
+	// Test that we get an error on an empty body.
+	status, response, err := GenericHandler("")
+	assert.Equal(t, 400, status)
+	assert.Equal(t, ErrRequestBodyEmpty, err)
+	assert.Equal(t, "", response)
+}
+
+func TestMalformedRequstError(t *testing.T) {
+	status, response, err := GenericHandler("i am not a valid JSON string")
+	assert.Equal(t, 400, status)
+	assert.Equal(t, ErrUnmarshalJSON, err)
+	assert.Equal(t, "", response)
+}


### PR DESCRIPTION
…other

cloud products as well.

Removed some log statements as well - we don't want to log requests and
responses here.